### PR TITLE
Add support for EIP2612 gasless approval

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paygrid-network/sdk",
-  "version": "0.1.0-beta.6",
+  "version": "0.1.0-beta.7",
   "description": "Official Paygrid Network TypeScript/JavaScript SDK - Chain-Agnostic Payment Clearing Network",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/core/constants/permit-config.ts
+++ b/src/core/constants/permit-config.ts
@@ -1,0 +1,49 @@
+// src/core/constants/permit-config.ts
+import { NetworkKey, TokenSymbol } from '../types';
+import { PermitType } from '../types/permit';
+
+// EIP-712 type definitions
+export const EIP2612_PERMIT_TYPES = {
+  Permit: [
+    { name: 'owner', type: 'address' },
+    { name: 'spender', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' }
+  ]
+};
+
+export const DAI_PERMIT_TYPES = {
+  Permit: [
+    { name: 'holder', type: 'address' },
+    { name: 'spender', type: 'address' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'expiry', type: 'uint256' },
+    { name: 'allowed', type: 'bool' }
+  ]
+};
+
+// Token permit type mapping
+export const TOKEN_PERMIT_TYPES: Record<TokenSymbol, Partial<Record<NetworkKey, PermitType>>> = {
+  USDC: {
+    ETHEREUM: 'EIP2612',
+    POLYGON: 'EIP2612',
+    OPTIMISM: 'EIP2612',
+    ARBITRUM: 'EIP2612',
+    BASE: 'EIP2612'
+  },
+  USDT: {
+    ETHEREUM: 'REGULAR',
+    POLYGON: 'REGULAR',
+    OPTIMISM: 'REGULAR',
+    ARBITRUM: 'REGULAR',
+    BASE: 'REGULAR'
+  },
+  DAI: {
+    ETHEREUM: 'DAI',
+    POLYGON: 'DAI',
+    OPTIMISM: 'EIP2612',
+    ARBITRUM: 'EIP2612',
+    BASE: 'REGULAR'
+  }
+};

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -1,20 +1,13 @@
 import { SUPPORTED_NETWORKS } from '../constants/networks';
 import { SUPPORTED_TOKENS } from '../constants/tokens';
 import { TypedDataDomain, TypedDataField } from 'ethers';
+import { PermitType } from './permit';
 
 export type NetworkKey = keyof typeof SUPPORTED_NETWORKS;
 export type TokenSymbol = keyof typeof SUPPORTED_TOKENS;
 
 // Define final payment states
 export const FINAL_PAYMENT_STATES = ['COMPLETED', 'FAILED', 'CANCELLED'] as const;
-
-export type PermitType = 
-  | 'EIP2612'
-  | 'DAI'
-  | 'USDC_ETHEREUM'
-  | 'USDC_OPTIMISM'
-  | 'REGULAR'
-  | 'SKIP';
 
 export interface NetworkConfig {
   chainId: number;
@@ -181,6 +174,7 @@ export interface PaymentIntentResponse {
   createdAt: string; // ISO datetime
   updatedAt: string; // ISO datetime
 }
+
 
 export type EIP712Domain = TypedDataDomain;
 export type EIP712Types = Record<string, TypedDataField[]>;

--- a/src/core/types/permit.ts
+++ b/src/core/types/permit.ts
@@ -1,0 +1,24 @@
+import { EIP712Domain, EIP712Types, EIP712Values } from './index';
+
+export type PermitType = 'EIP2612' | 'DAI' | 'REGULAR';
+
+export interface PermitSignaturePayload {
+  domain: EIP712Domain;
+  types: EIP712Types;
+  values: EIP712Values;
+}
+
+export interface PermitSignatureParams {
+  token: `0x${string}`;
+  owner: `0x${string}`;
+  spender?: `0x${string}`;
+  value?: bigint;
+  deadline: number;
+  nonce?: bigint;
+}
+
+export interface PermitSignature {
+  signature: string;
+  deadline: number;
+  nonce: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { PaymentIntentClient } from './services/payment.service';
 import { PaymentIntentSigner } from './services/payment-signer.service';
+import { PermitService } from './services/permit.service';
 import { ConfigUtils } from './utils/config';
 import { isSignTypedDataSupported } from './utils/eip712-support';
 import { PaymentIntent, Authorization, PaymentIntentResponse, PaymentType, ChargeBearer, RoutingPriority, OperatorData } from './core/types';
@@ -13,6 +14,7 @@ export {
     Authorization, 
     PaymentIntentResponse,
     PaymentIntentSigner,
+    PermitService,
     PaymentType,
     OperatorData,
     ChargeBearer,

--- a/src/services/permit.service.ts
+++ b/src/services/permit.service.ts
@@ -1,0 +1,181 @@
+// src/services/permit.service.ts
+import { ethers } from 'ethers';
+import { NetworkKey, TokenSymbol } from '../core/types';
+import { PermitSignature, PermitSignatureParams, PermitSignaturePayload } from '../core/types/permit';
+import { NETWORK_CONFIGS } from '../core/constants/networks';
+import { EIP2612_PERMIT_TYPES, DAI_PERMIT_TYPES } from '../core/constants/permit-config';
+import { 
+  getTokenNonce, 
+  getTokenNameAndVersion, 
+  getTokenPermitType, 
+  isPermitSupported 
+} from '../utils/permit-utils';
+import { isSignTypedDataSupported } from '../utils/eip712-support';
+import { PERMIT2_CONFIG } from '../core/constants/config';
+
+const GLOBAL_SPENDER = PERMIT2_CONFIG.ADDRESS;
+
+export class PermitService {
+  /**
+   * Generate a permit payload for EIP-2612 compatible tokens
+   */
+  private static async generateEIP2612Payload(
+    params: PermitSignatureParams,
+    provider: ethers.providers.Provider,
+    chainId: number
+  ): Promise<PermitSignaturePayload> {
+    const { token, owner, spender = GLOBAL_SPENDER, value = BigInt(ethers.constants.MaxUint256.toString()), deadline } = params;
+    
+    // Get token name and version
+    const { name, version } = await getTokenNameAndVersion(provider, token);
+    
+    // Get nonce if not provided
+    const nonce = params.nonce !== undefined 
+      ? params.nonce 
+      : await getTokenNonce(provider, token, owner);
+    
+    return {
+      domain: {
+        name,
+        version,
+        chainId,
+        verifyingContract: token
+      },
+      types: EIP2612_PERMIT_TYPES,
+      values: {
+        owner,
+        spender,
+        value,
+        nonce,
+        deadline
+      }
+    };
+  }
+  
+  /**
+   * Generate a permit payload for DAI token
+   */
+  private static async generateDAIPayload(
+    params: PermitSignatureParams,
+    provider: ethers.providers.Provider,
+    chainId: number
+  ): Promise<PermitSignaturePayload> {
+    const { token, owner, spender = GLOBAL_SPENDER, deadline } = params;
+    
+    // Get token name
+    const { name } = await getTokenNameAndVersion(provider, token);
+    
+    // Get nonce if not provided
+    const nonce = params.nonce !== undefined 
+      ? params.nonce 
+      : await getTokenNonce(provider, token, owner);
+    
+    return {
+      domain: {
+        name,
+        version: '1',
+        chainId,
+        verifyingContract: token
+      },
+      types: DAI_PERMIT_TYPES,
+      values: {
+        holder: owner,
+        spender,
+        nonce,
+        expiry: deadline,
+        allowed: true
+      }
+    };
+  }
+  
+  /**
+   * Generate a permit payload based on token and network
+   */
+  static async getPermitPayload(
+    tokenSymbol: TokenSymbol,
+    network: NetworkKey,
+    params: PermitSignatureParams,
+    provider: ethers.providers.Provider
+  ): Promise<PermitSignaturePayload> {
+
+    const token_symbol = tokenSymbol.toUpperCase() as TokenSymbol;
+    const network_key = network.toUpperCase() as NetworkKey;
+
+    // Check if permit is supported
+    const permitType = getTokenPermitType(token_symbol, network_key);
+    if (!permitType || permitType === 'REGULAR') {
+      throw new Error(`Token ${token_symbol} does not support permit on ${network_key}`);
+    }
+    
+    // Get network chain ID
+    const networkConfig = NETWORK_CONFIGS[network_key];
+    const chainId = networkConfig.chainId;
+    
+    // Generate payload based on permit type
+    switch (permitType) {
+      case 'EIP2612':
+        return this.generateEIP2612Payload(params, provider, chainId);
+      case 'DAI':
+        return this.generateDAIPayload(params, provider, chainId);
+      default:
+        throw new Error(`Unsupported permit type for ${token_symbol} on ${network_key}`);
+    }
+  }
+  
+  /**
+   * Generate and sign a permit for a token on a specific network
+   */
+  static async generateAndSignPermit(
+    tokenSymbol: TokenSymbol,
+    network: NetworkKey,
+    params: PermitSignatureParams,
+    signer: ethers.Signer
+  ): Promise<PermitSignature> {
+    // Check if signer has a provider
+    const provider = signer.provider;
+    if (!provider) {
+      throw new Error('Signer must be connected to a provider');
+    }
+    
+    try {
+      // Get permit payload
+      const payload = await this.getPermitPayload(tokenSymbol, network, params, provider);
+      
+      // Ensure signer supports EIP-712
+      const _signer = isSignTypedDataSupported(signer);
+      
+      // Get nonce for return value
+      const nonce = params.nonce !== undefined 
+        ? params.nonce 
+        : await getTokenNonce(provider, params.token, params.owner);
+      
+      // Sign the permit
+      const signature = await _signer._signTypedData(
+        payload.domain,
+        payload.types,
+        payload.values
+      );
+      
+      return {
+        signature,
+        deadline: params.deadline,
+        nonce: nonce.toString()
+      };
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes('user rejected')) {
+          throw new Error('User rejected the permit signature request');
+        }
+        throw new Error(`Permit generation failed: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+  
+  /**
+   * Check if a token supports permit on a specific network
+   */
+  static isPermitSupported(tokenSymbol: TokenSymbol, network: NetworkKey): boolean {
+    return isPermitSupported(tokenSymbol, network);
+  }
+}

--- a/src/utils/permit-utils.ts
+++ b/src/utils/permit-utils.ts
@@ -1,0 +1,92 @@
+// src/utils/permit-utils.ts
+import { ethers } from 'ethers';
+import { NETWORK_CONFIGS } from '../core/constants/networks';
+import { TOKEN_CONFIGS } from '../core/constants/tokens';
+import { NetworkKey, TokenSymbol } from '../core/types';
+import { PermitType } from '../core/types/permit';
+import { TOKEN_PERMIT_TYPES } from '../core/constants/permit-config';
+
+// ABI for fetching nonce
+const NONCE_ABI = [
+  {
+    inputs: [{ name: 'owner', type: 'address' }],
+    name: 'nonces',
+    outputs: [{ name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  }
+];
+
+/**
+ * Get token nonce for a specific owner
+ */
+export async function getTokenNonce(
+  provider: ethers.providers.Provider,
+  tokenAddress: string,
+  ownerAddress: string
+): Promise<bigint> {
+  const contract = new ethers.Contract(tokenAddress, NONCE_ABI, provider);
+  const nonce = await contract.nonces(ownerAddress);
+  return BigInt(nonce.toString());
+}
+
+/**
+ * Get token name and version for EIP-712 domain
+ */
+export async function getTokenNameAndVersion(
+  provider: ethers.providers.Provider,
+  tokenAddress: string
+): Promise<{ name: string; version: string }> {
+  // Define ABIs for name and version
+  const nameAbi = [
+    { inputs: [], name: 'name', outputs: [{ type: 'string' }], stateMutability: 'view', type: 'function' }
+  ];
+  const versionAbi = [
+    { inputs: [], name: 'version', outputs: [{ type: 'string' }], stateMutability: 'view', type: 'function' }
+  ];
+  
+  // Create contracts
+  const nameContract = new ethers.Contract(tokenAddress, nameAbi, provider);
+  
+  // Get name and version
+  let name: string;
+  try {
+    name = await nameContract.name();
+  } catch (e) {
+    name = "Unknown Token";
+  }
+  
+  let version: string;
+  try {
+    const versionContract = new ethers.Contract(tokenAddress, versionAbi, provider);
+    version = await versionContract.version();
+  } catch (e) {
+    version = "1";
+  }
+  
+  return { name, version };
+}
+
+/**
+ * Get the permit type for a token on a specific network
+ */
+export function getTokenPermitType(
+  tokenSymbol: TokenSymbol,
+  network: NetworkKey
+): PermitType | null {
+  const tokenPermits = TOKEN_PERMIT_TYPES[tokenSymbol];
+  if (!tokenPermits) return null;
+  
+  return tokenPermits[network] || null;
+}
+
+/**
+ * Check if a token supports permit on a specific network
+ */
+export function isPermitSupported(
+  tokenSymbol: TokenSymbol,
+  network: NetworkKey
+): boolean {
+  const permitType = getTokenPermitType(tokenSymbol, network);
+  return permitType !== null && permitType !== 'REGULAR';
+}


### PR DESCRIPTION
- Added EIP-2612 permit signature generation for gasless token approvals
- Implemented token-specific permit type mapping across different networks
- Created utility functions for fetching token nonces and constructing EIP-712 domains
- Exposed methods to generate permit payloads for inspection and manual signing
- Updated README with clear examples of permit generation and usage
- Integrated permit functionality with existing payment intent authorization flow